### PR TITLE
Fix build script and remove duplicate default parameter

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 mkdir -p build
-g++-14 -O3 -fopenmp *.cpp -o ns2d
+g++ -O3 -fopenmp *.cpp -o ns2d
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
 ./ns2d
 

--- a/solver.cpp
+++ b/solver.cpp
@@ -160,7 +160,7 @@ HLLFlux compute_hll_flux_y(double rhoL, double uL, double vL, double pL, double 
 }
 
 // Compute dynamic CFL timestep
-double compute_cfl_timestep(const FlowField& flow, double cfl_number = 0.4) {
+double compute_cfl_timestep(const FlowField& flow, double cfl_number) {
     double dt_min = 1e10;
     const Grid& grid = flow.rho;
     


### PR DESCRIPTION
## Summary
- use `g++` in build script for compatibility
- remove duplicate default parameter from `compute_cfl_timestep`

## Testing
- `./run.sh` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a7f26a400832e96f8eadb45ab86e1