### PR TITLE
Implement divergence damping

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -42,6 +42,9 @@ int main(){
 
         solve_MHD(amr,flows,dt,nu,0,0.0);
 
+        // Additional damping to ensure divergence errors do not accumulate
+        damp_divergence(flows[0], dt);
+
         if(step%output_every==0){
             std::cout << "step "<< std::setw(4) << step
                       << " dt="<<dt<<"\n";

--- a/solver.hpp
+++ b/solver.hpp
@@ -4,4 +4,6 @@
 void solve_MHD(AMRGrid& amr, std::vector<FlowField>& flows,double dt,double nu,int max_iter,double tol);
 // Estimate stable timestep based on CFL condition
 double compute_cfl_timestep(const FlowField& flow, double cfl_number = 0.4);
-std::pair<double, double> compute_divergence_errors(const FlowField& flow);  // Add this line
+std::pair<double, double> compute_divergence_errors(const FlowField& flow);
+// Damp accumulated divergence errors in psi field
+void damp_divergence(FlowField& flow, double dt);


### PR DESCRIPTION
## Summary
- damp psi field each step to reduce accumulated divergence
- add header for divergence damping function
- call damp_divergence in main loop

## Testing
- `g++ -O3 -fopenmp *.cpp -o ns2d`
- `./ns2d`

------
https://chatgpt.com/codex/tasks/task_e_684a8f2a02e0832ebbef9c875b38f39c