### PR TITLE
Limit AMR refinement to one level and simplify animation

### DIFF
--- a/animate_amr.py
+++ b/animate_amr.py
@@ -1,7 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
-from matplotlib.patches import Rectangle
 
 import postprocess as pp
 
@@ -19,17 +18,7 @@ def update(step):
     ax.clear()
     rho = pp.load_field("rho", step, xs, ys)
     c = ax.contourf(X, Y, rho, levels=40, cmap="viridis")
-    grid_file = f"Result/grid_{step}.csv"
-    try:
-        data = np.loadtxt(grid_file, delimiter=",")
-        if data.ndim == 1:
-            data = data[None, :]
-        for lvl, x0, y0, dx, dy, nx, ny in data:
-            rect = Rectangle((x0, y0), dx * (nx - 1), dy * (ny - 1),
-                             fill=False, edgecolor="red", lw=1)
-            ax.add_patch(rect)
-    except OSError:
-        pass
+    # skip drawing AMR grid overlays
     ax.set_title(f"step {step}")
     ax.set_aspect("equal")
     return c.collections

--- a/grid.hpp
+++ b/grid.hpp
@@ -4,7 +4,7 @@
 #include <string>
 
 // Maximum number of AMR patches allowed in a single run
-constexpr int MAX_REFINEMENTS = 5;
+constexpr int MAX_REFINEMENTS = 1;  // limit to a single refinement
 extern int refinement_count;
 
 /**

--- a/main.cpp
+++ b/main.cpp
@@ -28,7 +28,7 @@ int main(){
 
     std::string out_dir = prepare_output_dir();
 
-    AMRGrid amr(nx,ny,Lx,Ly,3); // allow up to 3 refinement levels
+    AMRGrid amr(nx,ny,Lx,Ly,1); // limit refinement to a single level
     std::vector<FlowField> flows;
     flows.emplace_back(nx,ny,dx,dy);
     initialize_MHD_disk(flows[0]); // deterministic seed default


### PR DESCRIPTION
## Summary
- restrict AMR to a single refinement patch
- create AMR grid with only one level
- remove red grid overlay from the animation

## Testing
- `bash run.sh` *(fails: g++-14: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b44de0d5c832ea60a7f775592018b